### PR TITLE
Change no_hats convar default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tftrue_maxfov
 Sets the maximum fov the players will be able to set with the "!fov" chat command. Default is 90.
 
 tftrue_no_hats  
-Enables/disables the hats. Default is 1 (hats disabled).
+Enables/disables the hats. Default is 0 (hats enabled).
 
 tftrue_no_misc  
 Enables/disables the misc items. Default is 0 (misc items enabled).

--- a/items.cpp
+++ b/items.cpp
@@ -22,11 +22,11 @@
 
 CItems g_Items;
 
-ConVar tftrue_no_hats("tftrue_no_hats", "1", FCVAR_NOTIFY, "Activate/Desactivate hats.",
+ConVar tftrue_no_hats("tftrue_no_hats", "0", FCVAR_NOTIFY, "Activate/Deactivate hats.",
 					  true, 0, true, 1, CItems::RebuildWhitelist);
-ConVar tftrue_no_misc("tftrue_no_misc", "0", FCVAR_NOTIFY, "Activate/Desactivate misc items.",
+ConVar tftrue_no_misc("tftrue_no_misc", "0", FCVAR_NOTIFY, "Activate/Deactivate misc items.",
 					  true, 0, true, 1, CItems::RebuildWhitelist);
-ConVar tftrue_no_action("tftrue_no_action", "0", FCVAR_NOTIFY, "Activate/Desactivate action items.",
+ConVar tftrue_no_action("tftrue_no_action", "0", FCVAR_NOTIFY, "Activate/Deactivate action items.",
 						true, 0, true, 1, CItems::RebuildWhitelist);
 ConVar tftrue_whitelist_id("tftrue_whitelist_id", "-1", FCVAR_NOTIFY, "ID of the whitelist to use from whitelist.tf", CItems::RebuildWhitelist);
 


### PR DESCRIPTION
Changes the tftrue no hats setting to default to 0 instead of 1 + typos (fixing #11 )

This way hats are allowed and need to be manually disabled through changing the setting or a custom whitelist.