### PR TITLE
nontrivial changes to not reload or redownload the whitelist when we don't need to, by:

### DIFF
--- a/SDK.h
+++ b/SDK.h
@@ -32,6 +32,13 @@
 #include "inetchannel.h"
 #include "replay/ienginereplay.h"
 
+// we do this so we can change cvar flags easier
+#define protected public
+#define private public
+#include <tier1/convar.h>
+#undef protected
+#undef private
+
 #include "cbase.h"
 #include "gamemovement.h"
 

--- a/SDK.h
+++ b/SDK.h
@@ -32,13 +32,6 @@
 #include "inetchannel.h"
 #include "replay/ienginereplay.h"
 
-// we do this so we can change cvar flags easier
-#define protected public
-#define private public
-#include <tier1/convar.h>
-#undef protected
-#undef private
-
 #include "cbase.h"
 #include "gamemovement.h"
 
@@ -48,7 +41,7 @@
 #include "steam/steam_api.h"
 #include "steam/steam_gameserver.h"
 
-extern IVEngineServer	*engine;
+extern IVEngineServer *engine;
 extern IPlayerInfoManager *playerinfomanager;
 extern ICvar *g_pCVar;
 extern IServerGameDLL *gamedll;

--- a/items.cpp
+++ b/items.cpp
@@ -19,8 +19,8 @@
 #include "items.h"
 #include "utils.h"
 #include "tournament.h"
-
 CItems g_Items;
+
 
 ConVar tftrue_no_hats("tftrue_no_hats", "0", FCVAR_NOTIFY,
 	"Activate/Deactivate hats.",
@@ -38,7 +38,8 @@ ConVar tftrue_no_action("tftrue_no_action", "0", FCVAR_NOTIFY,
 	CItems::RebuildWhitelist);
 
 ConVar tftrue_whitelist_id("tftrue_whitelist_id", "-1", FCVAR_NOTIFY,
-	"ID of the whitelist to use from whitelist.tf",
+	"ID of the whitelist to use from whitelist.tf.\n"
+	"If set to anything but -1, overrides the value of mp_tournament_whitelist",
 	true, -1, false, 0,
 	CItems::RebuildWhitelist);
 
@@ -48,7 +49,7 @@ CItems::CItems()
 	memset(szWhiteListChosen, 0, sizeof(szWhiteListChosen));
 
 	item_whitelist = new KeyValues("item_whitelist");
-	item_schema = new KeyValues("");
+	item_schema    = new KeyValues("");
 }
 
 CItems::~CItems()
@@ -153,6 +154,7 @@ bool CItems::Init(const CModuleScanner& ServerModule)
 	return (GetLoadoutItem && ItemSystem && ReloadWhitelist && GetItemDefinition &&
 			RemoveWearable && GiveDefaultItems);
 }
+
 void CItems::OnUnload()
 {
 	ConVarRef mp_tournament_whitelist("mp_tournament_whitelist");
@@ -180,51 +182,109 @@ char *CItems::GetAttributeValue(KeyValues *pKItem, const char *szAttribute)
 			while(pPrefab != NULL)
 			{
 				pKPrefab = item_schema->FindKey("prefabs", true)->FindKey(pPrefab, false);
-				if(pKPrefab)
+				if (pKPrefab)
 				{
 					szValue = (char*)pKPrefab->GetString(szAttribute, NULL);
 
 					// If our prefab has a prefab, then call GetAttributeValue on the prefab
 					const char *szPrefabPrefabName = pKPrefab->GetString("prefab", NULL);
 					if(szPrefabPrefabName)
+					{
 						szValue = GetAttributeValue(pKPrefab, szAttribute);
+					}
 
 					// If we have found the attribute, get out of the loop
 					if(szValue)
+					{
 						break;
+					}
 				}
 
 				pPrefab = strtok(NULL, " ");
 			}
 		}
 	}
-
 	return szValue;
 }
 
+
+void CItems::TournamentWhitelistCallback(IConVar *var, const char *pOldValue, float flOldValue)
+{
+	// we're using tftrue_whitelist_id
+	if (strcmp(tftrue_whitelist_id.GetString(), "-1") != 0)
+	{
+		Msg("[TFTrue] tftrue_whitelist_id = %s! mp_tournament_whitelist updated, ignoring!\n", tftrue_whitelist_id.GetString());
+	}
+	// we're not using tftrue whitelist id
+	else
+	{
+		Msg("[TFTrue] tftrue_whitelist_id = %s! mp_tournament_whitelist updated, reloading whitelist!\n", tftrue_whitelist_id.GetString());
+
+		static ConVarRef mp_tournament_whitelist("mp_tournament_whitelist");
+		V_strncpy(g_Items.szWhiteListChosen, mp_tournament_whitelist.GetString(), sizeof(g_Items.szWhiteListChosen));
+		RebuildWhitelist(NULL, NULL, 0.0);
+	}
+}
+
+
+
 void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldValue)
 {
-	g_Items.item_whitelist->Clear();
+	static ConVarRef mp_tournament_whitelist("mp_tournament_whitelist");
+	ConVar* mptw = (ConVar*)mp_tournament_whitelist.GetLinkedConVar();
 
-	if(tftrue_whitelist_id.GetInt() != -1)
+	bool using_id = false;
+	char szConfigPath[50];
+	// we're using tftrue_whitelist_id
+	if (strcmp(tftrue_whitelist_id.GetString(), "-1") != 0)
 	{
+		Msg("[TFTrue] -> Using tftrue_whitelist_id as tftrue_whitelist_id != -1...\n");
+
+		using_id = true;
+		ConVar* v = (ConVar*)var;
+
+		if (!(mptw->IsFlagSet( FCVAR_DEVELOPMENTONLY )))
+		{
+			Msg("[TFTrue] -> Setting mp_tournament_whitelist to FCVAR_DEVELOPMENTONLY...\n");
+			mptw->m_nFlags |= FCVAR_DEVELOPMENTONLY;
+		}
+
+		// if our var that changed is tftrue_whitelist_id
+		if (v == &tftrue_whitelist_id)
+		{
+			// get the current and previous values to compare
+			const char* oldval = pOldValue;
+			const char* newval = v->GetString();
+
+			// we didn't change, don't do extra work
+			if (strcmp(oldval, newval) == 0)
+			{
+				Msg("[TFTrue] Not redownloading whitelist, tftrue_whitelist_id didn't change and isn't -1!\n");
+				return;
+			}
+		}
+
+		// something DID change, let's yeet our current whitelist and redownload it.
+		// TODO: Check file modification time and only allow updating every hour
+		g_Items.item_whitelist->Clear();
+
 		SOCKET sock = INVALID_SOCKET;
-		if(ConnectToHost("whitelist.tf", sock))
+		if (ConnectToHost("whitelist.tf", sock))
 		{
 			int iWhiteListID = 0;
 			char szConfigURL[50];
-			char szConfigPath[50];
+			//char szConfigPath[50];
 
 			// Handle int vs string whitelist ids
-			if(sscanf(tftrue_whitelist_id.GetString(), "%d", &iWhiteListID) == 1)
+			if (sscanf(tftrue_whitelist_id.GetString(), "%d", &iWhiteListID) == 1)
 			{
-				V_snprintf(szConfigURL, sizeof(szConfigURL), "whitelist.tf/custom_whitelist_%d.txt", tftrue_whitelist_id.GetInt());
-				V_snprintf(szConfigPath, sizeof(szConfigPath), "cfg/custom_whitelist_%d.txt", tftrue_whitelist_id.GetInt());
+				V_snprintf(szConfigURL, sizeof(szConfigURL),   "whitelist.tf/custom_whitelist_%d.txt", tftrue_whitelist_id.GetInt());
+				V_snprintf(szConfigPath, sizeof(szConfigPath), "cfg/custom_whitelist_%d.txt",          tftrue_whitelist_id.GetInt());
 			}
 			else
 			{
-				V_snprintf(szConfigURL, sizeof(szConfigURL), "whitelist.tf/%s.txt", tftrue_whitelist_id.GetString());
-				V_snprintf(szConfigPath, sizeof(szConfigPath), "cfg/%s.txt", tftrue_whitelist_id.GetString());
+				V_snprintf(szConfigURL, sizeof(szConfigURL),   "whitelist.tf/%s.txt", tftrue_whitelist_id.GetString());
+				V_snprintf(szConfigPath, sizeof(szConfigPath), "cfg/%s.txt",          tftrue_whitelist_id.GetString());
 			}
 
 			// Download our whitelist
@@ -233,7 +293,7 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 
 			// Read the whitelist display name for the tftrue commands
 			FileHandle_t fh = filesystem->Open(szConfigPath, "r", "MOD");
-			if(fh)
+			if (fh)
 			{
 				g_Items.item_whitelist->LoadFromFile(filesystem, szConfigPath, "MOD");
 				char szLine[255] = "";
@@ -247,22 +307,40 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 					g_Items.szWhiteListName[strlen(g_Items.szWhiteListName)-2] = '\0';
 				}
 				else
+				{
 					V_strncpy(g_Items.szWhiteListName, "custom", sizeof(g_Items.szWhiteListName));
+				}
 
 				filesystem->Close(fh);
 			}
 			else
+			{
 				V_strncpy(g_Items.szWhiteListName, "error", sizeof(g_Items.szWhiteListName));
+			}
 		}
 	}
+	// we're not using tftrue whitelist id
 	else
 	{
-		if(strcmp(g_Items.szWhiteListChosen, ""))
+		Msg("[TFTrue] -> Using mp_tournament_whitelist as tftrue_whitelist_id is unset...\n");
+
+		// unignore mp_tournament_whitelist
+		if (mptw->IsFlagSet( FCVAR_DEVELOPMENTONLY ))
+		{
+			Msg("[TFTrue] -> Reverting mp_tournament_whitelist...\n");
+			mptw->m_nFlags &= ~FCVAR_DEVELOPMENTONLY;
+		}
+
+		if (strcmp(g_Items.szWhiteListChosen, ""))
+		{
 			g_Items.item_whitelist->LoadFromFile(filesystem, g_Items.szWhiteListChosen, "MOD");
+		}
 	}
 
-	if(!g_Items.item_whitelist->FindKey("unlisted_items_default_to", false))
+	if (!g_Items.item_whitelist->FindKey("unlisted_items_default_to", false))
+	{
 		g_Items.item_whitelist->SetInt("unlisted_items_default_to", 1);
+	}
 
 	// Loop through all items
 	for ( KeyValues *pKItem = g_Items.item_schema->FindKey("items", true)->GetFirstTrueSubKey(); pKItem; pKItem = pKItem->GetNextTrueSubKey() )
@@ -274,36 +352,45 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 
 		// Make sure we have an item name and slot
 		if(!szItemName || !szItemSlot)
+		{
 			continue;
+		}
 
 		// Do not try to add the item called "default"
 		if(!strcmp(szItemName, "default"))
+		{
 			continue;
+		}
 
 		// Do not add base items
-		if(szBaseItem && !strcmp(szBaseItem, "1"))
+		if (szBaseItem && !strcmp(szBaseItem, "1"))
+		{
 			continue;
+		}
 
 		// Do not add craft tokens
 		if(szCraftClass && !strcmp(szCraftClass, "craft_token"))
+		{
 			continue;
+		}
 
 		// Add item to the whitelist
-
-		// a bit unclear if this g_Items is set after the if:
-		// http://cafe.elharo.com/programming/prefer-multiline-if/
 		if  (
 				   (tftrue_no_hats.GetInt()   && !strcmpi(szItemSlot, "head"))
 				|| (tftrue_no_misc.GetInt()   && !strcmpi(szItemSlot, "misc"))
 				|| (tftrue_no_action.GetInt() && !strcmpi(szItemSlot, "action"))
 			)
+		{
 			g_Items.item_whitelist->SetInt(szItemName, 0);
+		}
 	}
 
-	// Save the whitelist
-	static ConVarRef mp_tournament_whitelist("mp_tournament_whitelist");
-	g_Items.item_whitelist->SaveToFile(filesystem, "TFTrue_item_whitelist.txt", "MOD");
-	mp_tournament_whitelist.SetValue("TFTrue_item_whitelist.txt");
+	if (using_id)
+	{
+		// Save the whitelist
+		g_Items.item_whitelist->SaveToFile(filesystem, szConfigPath, "MOD");
+		mp_tournament_whitelist.SetValue(szConfigPath);
+	}
 
 	// Reload the whitelist
 	void *pEconItemSystem = reinterpret_cast<ItemSystemFn>(g_Items.ItemSystem)();
@@ -313,10 +400,13 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 	for ( int i = 1; i <= g_pServer->GetClientCount(); i++ )
 	{
 		CBasePlayer *pPlayer = (CBasePlayer*)CBaseEntity::Instance(i);
-		if(!pPlayer)
+		if (!pPlayer)
+		{
 			continue;
+		}
 
-		if(engine->GetPlayerNetInfo(pPlayer->entindex())) // Not a bot
+		// Not a bot
+		if(engine->GetPlayerNetInfo(pPlayer->entindex()))
 		{
 			// Remove taunt
 			*g_EntityProps.GetSendProp<int>(pPlayer, "m_Shared.m_nPlayerCond") &= ~TF2_PLAYERCOND_TAUNT;
@@ -333,7 +423,9 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 					pChild = *g_EntityProps.GetDataMapProp<EHANDLE>(pPlayer, "m_hMoveChild");
 				}
 				else
+				{
 					pChild = *g_EntityProps.GetDataMapProp<EHANDLE>(pChild, "m_hMovePeer");
+				}
 			}
 
 			// m_bRegenerating, set to true to keep ubercharge and other weapon data
@@ -341,15 +433,6 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 			reinterpret_cast<GiveDefaultItemsFn>(g_Items.GiveDefaultItems)(pPlayer);
 			*(bool *)(g_EntityProps.GetSendProp<char>(pPlayer, "m_hItem")-1) = false;
 		}
-	}
-}
-void CItems::TournamentWhitelistCallback(IConVar *var, const char *pOldValue, float flOldValue)
-{
-	static ConVarRef mp_tournament_whitelist("mp_tournament_whitelist");
-	if(strcmp(mp_tournament_whitelist.GetString(), "TFTrue_item_whitelist.txt")) // Might be unneeded now?
-	{
-		V_strncpy(g_Items.szWhiteListChosen, mp_tournament_whitelist.GetString(), sizeof(g_Items.szWhiteListChosen));
-		RebuildWhitelist(NULL, NULL, 0.0);
 	}
 }
 

--- a/items.cpp
+++ b/items.cpp
@@ -19,6 +19,8 @@
 #include "items.h"
 #include "utils.h"
 #include "tournament.h"
+#include "editablecommands.h"
+
 CItems g_Items;
 
 
@@ -226,15 +228,14 @@ void CItems::TournamentWhitelistCallback(IConVar *var, const char *pOldValue, fl
 	}
 }
 
-
-
 void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldValue)
 {
 	static ConVarRef mp_tournament_whitelist("mp_tournament_whitelist");
-	ConVar* mptw = (ConVar*)mp_tournament_whitelist.GetLinkedConVar();
+	EditableConVar* mptw = (EditableConVar*)(ConVar*)mp_tournament_whitelist.GetLinkedConVar();
 
 	bool using_id = false;
 	char szConfigPath[50];
+
 	// we're using tftrue_whitelist_id
 	if (strcmp(tftrue_whitelist_id.GetString(), "-1") != 0)
 	{

--- a/items.cpp
+++ b/items.cpp
@@ -274,7 +274,6 @@ void CItems::RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldVa
 		{
 			int iWhiteListID = 0;
 			char szConfigURL[50];
-			//char szConfigPath[50];
 
 			// Handle int vs string whitelist ids
 			if (sscanf(tftrue_whitelist_id.GetString(), "%d", &iWhiteListID) == 1)

--- a/items.h
+++ b/items.h
@@ -24,18 +24,18 @@
 #include "ModuleScanner.h"
 
 class CItems
-{	
+{
 public:
 	CItems();
 	~CItems();
 	bool Init(const CModuleScanner& ServerModule);
 	void OnUnload();
-	
+
 	char *GetAttributeValue(KeyValues *pKItem, const char *szAttribute);
-	
+
 	static void RebuildWhitelist(IConVar *var, const char *pOldValue, float flOldValue);
 	static void TournamentWhitelistCallback(IConVar *var, const char *pOldValue, float flOldValue);
-	
+
 	KeyValues *item_whitelist = nullptr;
 	KeyValues *item_schema = nullptr;
 	char szWhiteListChosen[MAX_PATH];

--- a/tournament.cpp
+++ b/tournament.cpp
@@ -626,10 +626,11 @@ void CTournament::DownloadConfig(const char *szURL, SOCKET sock, bool bOverwrite
 	pFilePath[0] = '\0';\
 
 	char szPacket[1024];
-	V_snprintf(szPacket, sizeof(szPacket), "GET /%s HTTP/1.1\r\n"
+	V_snprintf(szPacket, sizeof(szPacket), "GET /%s HTTP/2.0\r\n"
 										   "Host: %s\r\n"
-										   "Accept: */*\r\n"
-										   "Cache-Control: no-cache\r\n\r\n", pFilePath+1, szURLTemp);
+										   "Accept: */*\r\n\r\n", pFilePath+1, szURLTemp);
+										// Don't set no cache, let whitelisttf handle it
+										// "Cache-Control: no-cache\r\n"
 
 	if(send(sock, szPacket, strlen(szPacket), 0) <= 0) // Send the packet
 	{


### PR DESCRIPTION
setting mp_tournament_whitelist to the downloaded whitelist filename
setting mp_tournament_whitelist to developmentonly when tftrue_whitelist_id is not default, so that only we can change it
not reloading the whitelist if we don't actually need to if we're not using tftrue_whitelist_id
etc

This is a nontrivial change and should be thoroughly reviewed and tested b4 pushing to master