### PR TITLE
Create build on release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,14 @@ after_success:
 - git remote add origin-push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - git push -u origin-push ${TRAVIS_BRANCH}
 
+deploy:
+  provider: releases
+  api_key: ${GH_TOKEN}
+  file: ./TFTrue.so
+  skip_cleanup: true
+  draft: false
+  on:
+    tags: true
+
 # GH_TOKEN is a secret token defined in your travis proj
 


### PR DESCRIPTION
Implements my suggestion on #53, when a new GitHub Release is created Travis CI starts a new build and when finished uploads the TFTrue.so binary to the created release.