### PR TITLE
Airshot changes

### DIFF
--- a/logs.cpp
+++ b/logs.cpp
@@ -55,6 +55,7 @@ ConVar tftrue_logs_roundend("tftrue_logs_roundend", "1", FCVAR_NOTIFY,
 CLogs::CLogs()
 {
 	memset(m_uiLastHealOnHit, 0, sizeof(m_uiLastHealOnHit));
+	memset(m_uiLastDirectHitVictim, 0, sizeof(m_uiLastDirectHitVictim));
 	memset(m_szCurrentLogFile, 0, sizeof(m_szCurrentLogFile));
 	memset(m_szCurrentLogFileBackup, 0, sizeof(m_szCurrentLogFileBackup));
 	memset(m_szLastUploadedLog, 0, sizeof(m_szLastUploadedLog));
@@ -157,7 +158,7 @@ bool CLogs::Init(const CModuleScanner& EngineModule, const CModuleScanner& Serve
 	gameeventmanager->AddListener(this, "player_chargedeployed", true);
 	gameeventmanager->AddListener(this, "player_healonhit", true);
 	gameeventmanager->AddListener(this, "teamplay_round_start", true);
-
+	gameeventmanager->AddListener(this, "projectile_direct_hit", true);
 	return Event_PlayerHealedOther && Event_PlayerFiredWeapon &&
 			Event_PlayerDamage && GetKillingWeaponName && OnTakeDamage && g_Log;
 }
@@ -394,7 +395,7 @@ void CLogs::OnServerActivate()
 	m_flRedMedicLostUberAdvantage = 0.0f;
 
 	memset(m_uiLastHealOnHit, 0, sizeof(m_uiLastHealOnHit));
-
+	memset(m_uiLastDirectHitVictim, 0, sizeof(m_uiLastDirectHitVictim));
 	m_flLastLogUploadTriedTime = 0.0f;
 	m_iLastLogID = 0;
 }
@@ -697,7 +698,18 @@ void CLogs::FireGameEvent(IGameEvent *pEvent)
 		m_uiLastHealOnHit[iEntIndex-1] = iAmount;
 	}
 	else if( !strcmp(pEvent->GetName(), "teamplay_round_start"))
+	{
 		m_flLastRoundStart = gpGlobals->curtime;
+	}
+	else if ( !strcmp(pEvent->GetName(), "projectile_direct_hit"))
+	{
+		int iAttacker = pEvent->GetInt("attacker");
+		int iVictim = pEvent->GetInt("victim");
+		if (iVictim > 0)
+		{
+			m_uiLastDirectHitVictim[iAttacker-1] = iVictim;
+		}
+	}
 }
 
 void CLogs::Event_PlayerFiredWeapon( void *pTFGameStats, EDX CBasePlayer *pPlayer, bool bCritical )
@@ -889,8 +901,10 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 			char szRealDamage[32] = "";
 			char szCrit[32] = "";
 			char szAirshot[32] = "";
+			char szDirect[32] = "";
 			char szHeadshot[32] = "";
 			char szHealing[32] = "";
+			char szAirshotHeight[32] = "";
 
 			if(iDamageTaken != (int)(info.GetDamage()+0.5f))
 				V_snprintf(szRealDamage, sizeof(szRealDamage), " (realdamage \"%d\")", iDamageTaken);
@@ -900,7 +914,7 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 			else if(bMiniCrit)
 				V_strncpy(szCrit, " (crit \"minicrit\")", sizeof(szCrit));
 
-			if (info.GetInflictor() && (!strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_rocket") || !strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_energy_ball") || !strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_pipe")))
+			if (info.GetInflictor() && (!strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_rocket") || !strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_energy_ball") || !strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_pipe") || !strcmp(info.GetInflictor()->GetClassname(), "tf_projectile_healing_bolt")))
 			{
 				if(!(*g_EntityProps.GetDataMapProp<int>(pPlayer, "m_fFlags") & (FL_ONGROUND|FL_INWATER)))
 				{
@@ -908,22 +922,38 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 					trace_t trace;
 					Vector vAimerOrigin = pInfoVictim->GetAbsOrigin();
 					Vector vDirection;
+					Vector vhullMins;
+					Vector vhullMaxs;
 
 					AngleVectors(QAngle(90, 0, 0), &vDirection);
 					vDirection = vDirection * 8192 + vAimerOrigin;
+					// Values represent the area of a tf2 players bbox see: https://developer.valvesoftware.com/wiki/TF2/Team_Fortress_2_Mapper%27s_Reference
+					// Values are rounded down to allow for some leeway 
+					vhullMins.Init(24,24,0);
+					vhullMaxs.Init(-24,-24,0);
 
-					pRay.Init(vAimerOrigin, vDirection);
-
+					pRay.Init(vAimerOrigin,vDirection, vhullMins, vhullMaxs);
 					CTraceFilterWorldOnly traceFilter;
 
 					g_pEngineTrace->TraceRay(pRay, CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_HITBOX|CONTENTS_GRATE, &traceFilter, &trace);
 
 					if(trace.DidHit())
 					{
-						if(vAimerOrigin.DistTo(trace.endpos) >= 170.0)
+						// Calculate height using z difference instead of DistTo since using a ray with hulls introduces some x,y difference
+						float distance = abs(vAimerOrigin.z - trace.endpos.z);
+						if(distance >= 170.0)
+						{
 							V_strncpy(szAirshot, " (airshot \"1\")", sizeof(szAirshot));
+							V_snprintf(szAirshotHeight, sizeof(szAirshotHeight), " height \"%d\")",(int) distance);
+						}
 					}
 				}
+				// If the attacker hit the victim with a direct hit. For pipes a workaround(m_bTouched) is needed since the event "projectile_direct_hit" gets triggered after the damage
+				if (g_Logs.m_uiLastDirectHitVictim[IndexOfEdict(pEdictAttacker)] == IndexOfEdict(pEdictVictim) || !*g_EntityProps.GetSendProp<bool>(info.GetInflictor(), "m_bTouched"))
+				{
+					V_strncpy(szDirect, " (direct \"1\")", sizeof(szDirect));
+				}
+				g_Logs.m_uiLastDirectHitVictim[IndexOfEdict(pEdictAttacker)] = 0;
 			}
 
 			if(info.GetDamageCustom() == TF_CUSTOM_HEADSHOT || info.GetDamageCustom() == TF_CUSTOM_HEADSHOT_DECAPITATION)
@@ -935,7 +965,7 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 				V_snprintf(szHealing, sizeof(szHealing),
 						   " (healing \"%d\")", uiHealing);
 
-			V_snprintf(msg, sizeof(msg), "\"%s<%d><%s><%s>\" triggered \"damage\" against \"%s<%d><%s><%s>\" (damage \"%d\")%s (weapon \"%s\")%s%s%s%s\n",
+			V_snprintf(msg, sizeof(msg), "\"%s<%d><%s><%s>\" triggered \"damage\" against \"%s<%d><%s><%s>\" (damage \"%d\")%s (weapon \"%s\")%s%s%s%s%s%s\n",
 					   pInfoAttacker->GetName(),
 					   pInfoAttacker->GetUserID(),
 					   pInfoAttacker->GetNetworkIDString(),
@@ -950,6 +980,8 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 					   szHealing,
 					   szCrit,
 					   szAirshot,
+					   szAirshotHeight,
+					   szDirect,
 					   szHeadshot);
 			engine->LogPrint(msg);
 

--- a/logs.h
+++ b/logs.h
@@ -84,6 +84,8 @@ private:
 
 	unsigned int m_uiLastHealOnHit[34];
 
+	unsigned int m_uiLastDirectHitVictim[34];
+
 	static void __fastcall Event_PlayerHealedOther( void *pTFGameStats, EDX CBasePlayer *pPlayer, float flHealing );
 	static void __fastcall Event_PlayerFiredWeapon( void *pTFGameStats, EDX CBasePlayer *pPlayer, bool bCritical );
 	static void __fastcall Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, const CTakeDamageInfo &info, int iDamageTaken );


### PR DESCRIPTION
This PR changes a couple of things related to airshots.
It mostly includes a bunch of changes which I'd like to see get added/changed partially to allow for better custom log parsing.
<details>
<summary>Crossbow bolt hits now count as airshots (only on damage)</summary>

Pretty self explanatory in general a "fun feature" to have.
</details>
<details>
<summary>Airshots use a "RayHull" to check for the distance to the ground</summary>

This prevents some edge cases where the center of the players isn't above solid ground but the other 40% of the hitbox are.
I think there's a debate to be had if this should be implemented...
</details>
<details>
<summary>Added a direct property to indicate rockets/pipes directly hitting an opponent</summary>

Would allow for better identifying direct hit airshots and other things. Sadly a workaround for pipes needed to be added since the event "projectile_direct_hit" gets triggered after the damage event in tf2s source code (see: [this](https://github.com/mastercomfig/team-comtress-2/blob/d3ee4cf0aafa5adfa5096c3c6c7a6748a1784a97/src/game/shared/tf/tf_weaponbase_grenadeproj.cpp#L395))
</details>
<details>
<summary>Added a height property to indicate the distance from the player to the ground when they got airshot</summary>

Would allow for some kind of filtering between "good" and "bad" airshots. I was considering adding this to the airshot property but logs.tf doesn't seem to parse this properly.
</details>

Like I mentioned these are mostly suggestions and I'm most of it is up to debate if it should even be implemented. 
I'd of course be willing to update/change things if needed :)