### PR TITLE
Reset LastHealOnHit once it has been logged

### DIFF
--- a/logs.cpp
+++ b/logs.cpp
@@ -929,11 +929,15 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 			if(info.GetDamageCustom() == TF_CUSTOM_HEADSHOT || info.GetDamageCustom() == TF_CUSTOM_HEADSHOT_DECAPITATION)
 				V_strncpy(szHeadshot, " (headshot \"1\")", sizeof(szHeadshot));
 
-			unsigned int uiHealing = g_Logs.m_uiLastHealOnHit[IndexOfEdict(pEdictAttacker)];
+			int iAttackerIndex = IndexOfEdict(pEdictAttacker);
+			unsigned int uiHealing = g_Logs.m_uiLastHealOnHit[iAttackerIndex];
 
 			if(uiHealing > 0)
+			{
 				V_snprintf(szHealing, sizeof(szHealing),
 						   " (healing \"%d\")", uiHealing);
+				g_Logs.m_uiLastHealOnHit[iAttackerIndex] = 0;
+			}
 
 			V_snprintf(msg, sizeof(msg), "\"%s<%d><%s><%s>\" triggered \"damage\" against \"%s<%d><%s><%s>\" (damage \"%d\")%s (weapon \"%s\")%s%s%s%s\n",
 					   pInfoAttacker->GetName(),


### PR DESCRIPTION
### Note: I am not able to compile/test my changes. Please thoroughly verify the code before accepting.

I noticed in logs ([example](https://logs.tf/3141574)) that damage logs would often include the same "healing" attribute, like this:

```
L 02/28/2022 - 20:53:36: "Martin<11><[U:1:3151199]><Red>" triggered "damage" against "dwo69<5><[U:1:40354909]><Blue>" (damage "14") (weapon "scattergun") (healing "118")
L 02/28/2022 - 20:53:37: "Martin<11><[U:1:3151199]><Red>" triggered "damage" against "acanta<8><[U:1:167002869]><Blue>" (damage "3") (weapon "scattergun") (healing "118")
L 02/28/2022 - 20:53:38: "Martin<11><[U:1:3151199]><Red>" triggered "damage" against "azn<4><[U:1:31135245]><Blue>" (damage "11") (weapon "scattergun") (healing "118")
```

Looking at the code, I noticed that `m_uiLastHealOnHit` is being set when "healonhit" is triggered, but it doesn't seem to be reset until you pick up a medkit.

This PR suggests resetting it when it has been logged once.