### PR TITLE
Fix "first heal" being logged as 20s on new round

### DIFF
--- a/logs.cpp
+++ b/logs.cpp
@@ -446,8 +446,7 @@ void CLogs::LogHealing(int iHealer, int iPatient, int iAmount)
 					   pPatientInfo->GetNetworkIDString(), PatientTeam, iAmount);
 			engine->LogPrint(msg);
 
-			if(flMedicLastSpawnTime > 0.0f && m_flLastRoundStart > 0.0f
-					&& gpGlobals->curtime - m_flLastRoundStart >= 20.0f)
+			if(flMedicLastSpawnTime > 0.0f && m_flLastRoundStart > 0.0f)
 			{
 				V_snprintf(msg, sizeof(msg),
 						   "\"%s<%d><%s><%s>\" triggered \"first_heal_after_spawn\" (time \"%.1f\")\n",


### PR DESCRIPTION
### Note: I am not able to compile/test my changes. Please thoroughly verify the code before accepting.

I noticed that the "first_heal_after_spawn" log event is being logged way too late in new rounds. See [this example](https://logs.tf/3141574):

```
L 02/28/2022 - 20:53:34: "acanta<8><[U:1:167002869]><Blue>" triggered "first_heal_after_spawn" (time "20.1")
L 02/28/2022 - 20:53:34: "F2<14><[U:1:77320]><Red>" triggered "first_heal_after_spawn" (time "20.1")
(...)
L 02/28/2022 - 21:18:23: "acanta<8><[U:1:167002869]><Blue>" triggered "first_heal_after_spawn" (time "20.7")
L 02/28/2022 - 21:18:23: "F2<14><[U:1:77320]><Red>" triggered "first_heal_after_spawn" (time "20.7")
```

The code delays this log event for 20 seconds, but I don't understand why? Can't we just remove this condition?

