### PR TITLE
Added missing parenthesis for height

### DIFF
--- a/logs.cpp
+++ b/logs.cpp
@@ -978,7 +978,7 @@ void CLogs::Event_PlayerDamage( void *pTFGameStats, EDX CBasePlayer *pPlayer, co
 						if(distance >= 170.0)
 						{
 							V_strncpy(szAirshot, " (airshot \"1\")", sizeof(szAirshot));
-							V_snprintf(szAirshotHeight, sizeof(szAirshotHeight), " height \"%d\")",(int) distance);
+							V_snprintf(szAirshotHeight, sizeof(szAirshotHeight), " (height \"%d\")",(int) distance);
 						}
 					}
 				}


### PR DESCRIPTION
At some point when rewriting some of the code to improve the logging of airshots I seen to have forgotten a parenthesis.

It doesn't break anything but probably shouldn't be like this forever.